### PR TITLE
feat(workflow): add cubic review to agent contracts

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -26,10 +26,9 @@ Canonical workflow contract for AI coding agents in this repository.
 ## Required Checks
 - `CI / tests-and-repo-checks`
 - `PR Policy / enforce-pr-policy`
-- Automated Code Review: `cubic review --base main` (must pass with no issues)
 
 ## Required Commands
-- Code Review: Use `cubic cli` and `cubic mcp` for code reviews. Run `cubic review --base main` (or `cubic review --base <branch>` or auto-detect with `cubic review --base`) to review changes against the base branch. Repeat until no issues remain before merging.
+- Automated Code Review (local, not a GitHub status check): Use `cubic cli` and `cubic mcp` for code reviews. Run `cubic review --base main` (or `cubic review --base <branch>` or auto-detect with `cubic review --base`) to review changes against the base branch. Repeat until no issues remain before merging.
 - New worktree: `scripts/new_worktree.sh <agent:codex|claude> <type> <issue> <slug>`
 - Sync with main: `scripts/sync_main.sh`
 - Sync repo-managed skills into Codex home: `scripts/sync_skills.sh`

--- a/skills/repo-commit-pr-flow/SKILL.md
+++ b/skills/repo-commit-pr-flow/SKILL.md
@@ -25,7 +25,7 @@ Use this skill when changes are ready to commit, push, or publish as a PR.
 2. Validate before commit.
 - Run relevant tests/checks for changed scope.
 - Ensure no policy-violating files are included.
-- Use `cubic cli` and `cubic mcp` to review changes against the base branch (e.g., `cubic review --base main` or `cubic review --base` for auto-detect).
+- Use `cubic cli` and `cubic mcp` to review changes against the base branch (e.g., `cubic review --base main` or `cubic review --base` for auto-detect). This step assumes your `cubic` setup can see staged/uncommitted changes; if it only reviews committed diffs between branches, run `cubic review` after step 3 (Commit) instead.
 - Address any issues found by `cubic` and re-run until no issues remain.
 
 3. Commit.
@@ -45,7 +45,7 @@ Use this skill when changes are ready to commit, push, or publish as a PR.
 - Required checks are green:
   - `CI / tests-and-repo-checks`
   - `PR Policy / enforce-pr-policy`
-  - Automated Code Review (`cubic review --base main`) passed with no issues.
+- Local validation: Automated Code Review (`cubic review --base main`) has been run and passed with no issues (this is a local check, not a PR status check).
 - Branch is up to date with `origin/main`.
 - Merge method remains squash-and-merge.
 


### PR DESCRIPTION
Refs #57

Update `AGENT.md` and `repo-commit-pr-flow` skill to enforce automated code reviews using `cubic cli` and `cubic mcp` before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #57 by adding a required local cubic review (CLI + MCP) before merge and updating AGENT.md and repo-commit-pr-flow with clear steps.

- **New Features**
  - AGENT.md: Adds local automated review with cubic; run “cubic review --base main” (or select/auto-detect base) and repeat until clean.
  - repo-commit-pr-flow: Adds validation to run cubic before commit (or after commit if it only reviews committed diffs), fix findings, and require a clean local pass in “Merge PR” (not a GitHub status check).

<sup>Written for commit 330754d3aee503996beaa6ba42a3a20f213ba082. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

