### PR TITLE
chore(workflow): document permanent workflow tracker issue

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -22,6 +22,9 @@ Canonical workflow contract for AI coding agents in this repository.
    - before opening or updating a PR
 9. Merge using **Squash and merge** only.
 10. For code-change workflow tasks, apply `repo-workflow-env` and `repo-commit-pr-flow`. For PR review comments, apply `gh-address-comments`. For failing checks, apply `gh-fix-ci`.
+11. Keep `#59` as the permanent workflow-improvements tracker:
+   - Never close issue `#59`.
+   - Workflow/process policy PRs should include `Refs #59` in the PR body.
 
 ## Required Checks
 - `CI / tests-and-repo-checks`


### PR DESCRIPTION
## Summary
- add a workflow-policy rule in `AGENT.md` that designates issue #59 as the permanent workflow-improvements tracker
- require workflow/process PRs to include `Refs #59`
- explicitly state that issue #59 must never be closed

## Linked Issue
Refs #59
- This PR does not close #59; #59 is intentionally permanent and must remain open.

## Validation
- [ ] `python -m unittest discover -s tests -p "test_*.py" -v` (not run; docs/policy-only change)
- [ ] `python tests/run_repo_checks.py` (not run; docs/policy-only change)
- [ ] If this PR changes LLM/tool-calling behavior or agent workflow logic, run local eval(s) and include commands/results in PR description (not applicable)

## Workflow Checklist
- [x] Branch created via worktree (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [ ] CI checks pass
- [x] Merge method will be **Squash and merge**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a workflow policy in AGENT.md that designates issue #59 as the permanent workflow-improvements tracker. Requires workflow/process PRs to include "Refs #59" and clarifies that #59 must never be closed.

<sup>Written for commit 1ba8298128c8da9094aac5e4fccdfccdd88afba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

