### PR TITLE
refactor(orchestrator): isolate state per async run (#50)

### DIFF
--- a/backend/debug_test.py
+++ b/backend/debug_test.py
@@ -18,21 +18,20 @@ def debug_orchestrator():
     try:
         orchestrator = CoreOrchestrator('test_user')
         print("✅ Orchestrator created")
-        
-        # Setup the agent
-        orchestrator._setup_orchestrator_agent('test_conv')
-        print("✅ Agent setup called")
-        
-        # Check if agent was created
-        if orchestrator.orchestrator_agent:
+
+        run_registry = orchestrator.tool_registry.clone_with_selected_documents([])
+        agent = orchestrator._build_orchestrator_agent('test_conv', run_registry)
+        print("✅ Agent built")
+
+        if agent:
             print("✅ Agent created successfully")
-            print(f"Agent type: {type(orchestrator.orchestrator_agent)}")
+            print(f"Agent type: {type(agent)}")
         else:
             print("❌ Agent is None")
             return
-            
+
         # Show available tools
-        tools = orchestrator.tool_registry.get_available_tools()
+        tools = run_registry.get_available_tools()
         print(f"🔧 Available tools: {[tool.name for tool in tools]}")
         
         # Try to show the prompt (this might not work directly)

--- a/backend/orchestrator/core.py
+++ b/backend/orchestrator/core.py
@@ -51,7 +51,8 @@ class CoreOrchestrator:
     def __init__(self, user_id: str = "default"):
         self.user_id = user_id
         self.llm = None
-        self.tool_registry = ToolRegistry(user_id)  # used only for static tool listing
+        # Shared per-user registry for static tools, tool listing, and background summarisation.
+        self.tool_registry = ToolRegistry(user_id)
     
     def _setup_llm(self):
         """Setup the language model for the orchestrator."""
@@ -179,9 +180,9 @@ class CoreOrchestrator:
         ) as operation_observation:
             try:
                 self._ensure_llm()
-                # Build a fresh, run-scoped registry and agent to prevent cross-run
-                # state leakage when concurrent runs share the same orchestrator instance.
-                run_registry = ToolRegistry(self.user_id, selected_documents=selected_documents or [])
+                # Clone static tools and rebuild only document-scoped state per run
+                # so concurrent requests do not share mutable document context.
+                run_registry = self.tool_registry.clone_with_selected_documents(selected_documents)
                 run_agent = self._build_orchestrator_agent(conversation_id, run_registry)
 
                 # Save user message to database
@@ -227,7 +228,7 @@ class CoreOrchestrator:
                         result = run_agent.invoke({"messages": messages}, config=config)
                         orchestration_actions = self._extract_langgraph_actions(result["messages"]) if result and "messages" in result else []
                         tool_results = orchestration_actions if orchestration_actions else []
-                        response_agent_tool = run_registry._tools.get("response_agent")
+                        response_agent_tool = run_registry.get_tool("response_agent")
                         if response_agent_tool:
                             # Use condensed history for response agent as well
                             conversation_history = self.get_condensed_conversation_history(conversation_id)
@@ -254,7 +255,7 @@ class CoreOrchestrator:
                     fallback_used = True
                     orchestration_actions = self._run_rule_based_fallback(user_request, run_registry)
                     if orchestration_actions:
-                        response_agent_tool = run_registry._tools.get("response_agent")
+                        response_agent_tool = run_registry.get_tool("response_agent")
                         if response_agent_tool:
                             conversation_history = self.get_condensed_conversation_history(conversation_id)
                             response = response_agent_tool._run(
@@ -297,7 +298,6 @@ class CoreOrchestrator:
                 )
 
                 # Trigger summarisation in the background (do not await)
-                import asyncio
                 asyncio.create_task(self.maybe_summarise_conversation(conversation_id))
 
                 # Return response immediately
@@ -363,7 +363,7 @@ class CoreOrchestrator:
             token_count = len(history_text) // 4
             if token_count > int(context_window_tokens * threshold):
                 # Summarise
-                summarisation_agent = self.tool_registry._tools.get("summarisation_agent")
+                summarisation_agent = self.tool_registry.get_tool("summarisation_agent")
                 if summarisation_agent:
                     try:
                         summary = await summarisation_agent._arun(history_text)
@@ -453,7 +453,8 @@ class CoreOrchestrator:
         query_lower = query.lower()
 
         math_expression = self._extract_math_expression(query)
-        if math_expression and "calculator" in tool_registry._tools:
+        calculator_tool = tool_registry.get_tool("calculator")
+        if math_expression and calculator_tool:
             with observe_operation(
                 name="orchestrator.fallback.calculator",
                 counter_prefix="orchestrator.fallback.calculator",
@@ -461,14 +462,15 @@ class CoreOrchestrator:
                 input_data={"expression": math_expression},
                 metadata={"component": "orchestrator", "fallback": True},
             ):
-                output = tool_registry._tools["calculator"]._run(expression=math_expression)
+                output = calculator_tool._run(expression=math_expression)
                 actions.append({
                     "tool": "calculator",
                     "input": json.dumps({"expression": math_expression}, ensure_ascii=False),
                     "output": output,
                 })
 
-        if any(token in query_lower for token in ("time", "date", "day")) and "current_time" in tool_registry._tools:
+        current_time_tool = tool_registry.get_tool("current_time")
+        if any(token in query_lower for token in ("time", "date", "day")) and current_time_tool:
             with observe_operation(
                 name="orchestrator.fallback.current_time",
                 counter_prefix="orchestrator.fallback.current_time",
@@ -476,7 +478,7 @@ class CoreOrchestrator:
                 input_data={"query_chars": len(query)},
                 metadata={"component": "orchestrator", "fallback": True},
             ):
-                output = tool_registry._tools["current_time"]._run(query=query)
+                output = current_time_tool._run(query=query)
                 actions.append({
                     "tool": "current_time",
                     "input": json.dumps({"query": query}, ensure_ascii=False),
@@ -504,7 +506,8 @@ class CoreOrchestrator:
                 })
 
         internet_intent = any(token in query_lower for token in ("internet", "latest", "news", "headline", "headlines", "search the internet"))
-        if internet_intent and "internet_search" in tool_registry._tools:
+        internet_search_tool = tool_registry.get_tool("internet_search")
+        if internet_intent and internet_search_tool:
             with observe_operation(
                 name="orchestrator.fallback.internet_search",
                 counter_prefix="orchestrator.fallback.internet_search",
@@ -512,7 +515,7 @@ class CoreOrchestrator:
                 input_data={"query_chars": len(query), "provider": "duckduckgo"},
                 metadata={"component": "orchestrator", "fallback": True},
             ):
-                output = tool_registry._tools["internet_search"]._run(query=query, provider="duckduckgo")
+                output = internet_search_tool._run(query=query, provider="duckduckgo")
                 actions.append({
                     "tool": "internet_search",
                     "input": json.dumps({"query": query, "provider": "duckduckgo"}, ensure_ascii=False),

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -30,10 +30,10 @@ class ToolRegistry:
     
     def __init__(self, user_id: str = "default", selected_documents: Optional[List[str]] = None):
         self.user_id = user_id
-        self.selected_documents = selected_documents or []
+        self.selected_documents = list(selected_documents or [])
         self._tools = {}
         self._initialize_tools()
-    
+
     def _initialize_tools(self):
         """
         Initialize all available tools/agents.
@@ -42,10 +42,6 @@ class ToolRegistry:
         self._tools["calculator"] = CalculatorTool()
         self._tools["current_time"] = CurrentTimeTool()
         self._tools["scratchpad"] = ScratchpadTool(self.user_id)
-
-        # Context-dependent tools (only if documents are selected)
-        if self.selected_documents and len(self.selected_documents) > 0:
-            self._tools["search_documents"] = SearchDocumentsTool(self.user_id, self.selected_documents)
 
         gmail_ready, gmail_reasons = get_gmail_readiness(settings.enable_gmail_integration)
         if gmail_ready:
@@ -66,18 +62,34 @@ class ToolRegistry:
         self._tools["user_profile"] = UserProfileTool(self.user_id)
         # Summarisation agent (always available)
         self._tools["summarisation_agent"] = SummarisationAgent()
+        self._set_search_documents_tool(self.selected_documents)
+
+    def _set_search_documents_tool(self, selected_documents: Optional[List[str]]) -> None:
+        """Refresh the document-scoped search tool without rebuilding static tools."""
+        self.selected_documents = list(selected_documents or [])
+        if self.selected_documents:
+            self._tools["search_documents"] = SearchDocumentsTool(self.user_id, self.selected_documents)
+        else:
+            self._tools.pop("search_documents", None)
 
     def update_selected_documents(self, selected_documents: List[str]):
         """
         Update the context for document-dependent tools.
         """
-        self.selected_documents = selected_documents
-        # Reinitialize document search tool with new context
-        if self.selected_documents and len(self.selected_documents) > 0:
-            self._tools["search_documents"] = SearchDocumentsTool(self.user_id, self.selected_documents)
-        elif "search_documents" in self._tools:
-            del self._tools["search_documents"]
+        self._set_search_documents_tool(selected_documents)
         logger.info(f"Updated tool registry with {len(selected_documents)} selected documents")
+
+    def clone_with_selected_documents(self, selected_documents: Optional[List[str]] = None) -> "ToolRegistry":
+        """
+        Create a run-scoped registry that reuses static tool instances and rebuilds
+        only document-dependent state.
+        """
+        clone = object.__new__(ToolRegistry)
+        clone.user_id = self.user_id
+        clone._tools = {name: tool for name, tool in self._tools.items() if name != "search_documents"}
+        clone.selected_documents = []
+        clone._set_search_documents_tool(selected_documents)
+        return clone
 
     def get_available_tools(self) -> List[Any]:
         """

--- a/tests/test_core_orchestrator.py
+++ b/tests/test_core_orchestrator.py
@@ -4,7 +4,9 @@ Comprehensive tests for the Core Orchestrator functionality.
 import sys
 import os
 import asyncio
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 
 # Add project root to path
@@ -209,14 +211,21 @@ class TestCoreOrchestrator(unittest.TestCase):
         one run cannot leak into another run that uses different documents.
         """
         captured_registries = []
-
-        original_build = self.orchestrator._build_orchestrator_agent
+        capture_lock = threading.Lock()
+        overlap_barrier = threading.Barrier(2)
 
         def capturing_build(conversation_id, tool_registry):
-            captured_registries.append(tool_registry)
+            with capture_lock:
+                captured_registries.append(tool_registry)
+
             # Return a minimal mock agent that mimics the LangGraph interface
             mock_agent = MagicMock()
-            mock_agent.invoke.return_value = {"messages": []}
+
+            def invoke(*args, **kwargs):
+                overlap_barrier.wait(timeout=2)
+                return {"messages": []}
+
+            mock_agent.invoke.side_effect = invoke
             return mock_agent
 
         docs_a = ["doc-a"]
@@ -231,12 +240,18 @@ class TestCoreOrchestrator(unittest.TestCase):
             mock_db_ops.get_conversation_history.return_value = []
             mock_db_ops.save_message.return_value = None
 
-            asyncio.run(self.orchestrator.process_request(
-                "hello from A", "conv-a", selected_documents=docs_a
-            ))
-            asyncio.run(self.orchestrator.process_request(
-                "hello from B", "conv-b", selected_documents=docs_b
-            ))
+            def run_request(message, conversation_id, selected_documents):
+                asyncio.run(self.orchestrator.process_request(
+                    message, conversation_id, selected_documents=selected_documents
+                ))
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [
+                    executor.submit(run_request, "hello from A", "conv-a", docs_a),
+                    executor.submit(run_request, "hello from B", "conv-b", docs_b),
+                ]
+                for future in futures:
+                    future.result(timeout=5)
 
         self.assertEqual(len(captured_registries), 2)
         self.assertIsNot(captured_registries[0], captured_registries[1],

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -80,6 +80,17 @@ class TestToolRegistry(unittest.TestCase):
         registry.update_selected_documents(["doc-123"])
         self.assertIn("search_documents", [t.name for t in registry.get_available_tools()])
 
+    def test_clone_with_selected_documents_reuses_static_tools(self):
+        registry = self._build_registry(selected_documents=[])
+        clone = registry.clone_with_selected_documents(["doc-123"])
+
+        self.assertIsNot(clone, registry)
+        self.assertEqual(clone.selected_documents, ["doc-123"])
+        self.assertIn("search_documents", [t.name for t in clone.get_available_tools()])
+        self.assertIs(clone.get_tool("calculator"), registry.get_tool("calculator"))
+        self.assertIs(clone.get_tool("response_agent"), registry.get_tool("response_agent"))
+        self.assertIsNone(registry.get_tool("search_documents"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Removes shared mutable instance attributes (`current_conversation_id`, `orchestrator_agent`, `tool_registry.selected_documents`) from `CoreOrchestrator` that caused cross-run context leakage under concurrency.
- `process_request` now builds a fresh `ToolRegistry` and LangGraph agent per call — neither is written back to instance state — so concurrent runs for different conversations cannot overwrite each other's tool context or document selection.
- `_get_document_context` and `_run_rule_based_fallback` updated to accept the run-local registry as a parameter instead of reading from `self.tool_registry`.

## Linked Issue
Closes #50

## Validation
- [x] `python tests/run_unit_tests.py` — 172 tests run, 2 new isolation tests pass; only 4 pre-existing failures (present on `main` before this change)
- [x] `python tests/run_repo_checks.py` — 12/12 passed
- [x] No LLM/tool-calling behavior changed (pure structural refactor — same tools, same prompts, same DB operations)

New tests added:
- `test_process_request_uses_isolated_registry_per_run` — verifies sequential calls to `process_request` receive distinct `ToolRegistry` instances with correct `selected_documents`
- `test_process_request_does_not_store_agent_on_self` — asserts `orchestrator_agent` and `current_conversation_id` are not on the instance after a call

## Workflow Checklist
- [x] Branch created via worktree (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates orchestrator state per async run to prevent cross-run context leaks under concurrency. `process_request` now builds a fresh run-scoped `ToolRegistry` (via `clone_with_selected_documents`) and a new LangGraph agent per call; the instance no longer holds conversation-specific state (closes #50).

- **Refactors**
  - Removed `current_conversation_id`, `orchestrator_agent`, and `tool_registry.selected_documents` from instance state.
  - Added `_build_orchestrator_agent(conversation_id, tool_registry)` and updated `_get_document_context(tool_registry)` and `_run_rule_based_fallback(user_request, tool_registry)` to use the run-local registry.
  - Introduced `ToolRegistry.clone_with_selected_documents()` to reuse static tools while rebuilding `search_documents`; updated code paths to use `get_tool` where applicable. Retains existing behavior (same tools, prompts, and DB operations).

<sup>Written for commit d288519321fe09bec8b52773afe8d0c6d9b908f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

