### PR TITLE
fix(frontend): add SSE stream watchdog and soft timeout handling (#130)

### DIFF
--- a/frontend/components/WorkspaceApp.jsx
+++ b/frontend/components/WorkspaceApp.jsx
@@ -36,6 +36,13 @@ class RunTransportTimeoutError extends Error {
   }
 }
 
+function ensureError(error, fallbackMessage) {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(fallbackMessage);
+}
+
 function localId(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
@@ -537,9 +544,9 @@ export default function WorkspaceApp({ view, currentPath, initialConversationId 
                 latestEvent: mergedEvents[mergedEvents.length - 1] || previousRunState.latestEvent || null,
               };
             });
-          } catch {
+          } catch (error) {
             if (attempt === RUN_POLL_MAX_ATTEMPTS - 1) {
-              throw new RunTransportTimeoutError("Run status polling failed before terminal state");
+              throw ensureError(error, "Run status polling failed");
             }
             await sleep(RUN_POLL_INTERVAL_MS);
             continue;

--- a/frontend/lib/runStream.js
+++ b/frontend/lib/runStream.js
@@ -67,7 +67,7 @@ export function subscribeToRunStream(
 
   es.addEventListener("run_complete", (event) => {
     if (closed) return;
-    resetWatchdog();
+    clearWatchdog();
     let data;
     try {
       data = JSON.parse(event.data);

--- a/frontend/tests/runStream.test.js
+++ b/frontend/tests/runStream.test.js
@@ -24,7 +24,7 @@ describe('subscribeToRunStream', () => {
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 

--- a/frontend/tests/sendMessage.test.jsx
+++ b/frontend/tests/sendMessage.test.jsx
@@ -305,6 +305,7 @@ describe('sendMessage SSE vs fallback paths', () => {
   });
 
   afterEach(() => {
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 
@@ -389,7 +390,7 @@ describe('sendMessage SSE vs fallback paths', () => {
     expect(screen.getAllByText('Running').length).toBeGreaterThan(0);
   });
 
-  test('repeated polling failures exhaust into the same soft timeout path', async () => {
+  test('repeated polling failures still surface as a hard failure', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -415,12 +416,12 @@ describe('sendMessage SSE vs fallback paths', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(RUN_TRANSPORT_TIMEOUT_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByText('Failed to send message.')).toBeInTheDocument();
     });
 
-    expect(screen.queryByText('[Error: Failed to send message]')).not.toBeInTheDocument();
-    expect(screen.getByText(/Thinking/)).toBeInTheDocument();
-    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Queued').length).toBeGreaterThan(0);
+    expect(screen.getByText('[Error: Failed to send message]')).toBeInTheDocument();
+    expect(screen.queryByText(RUN_TRANSPORT_TIMEOUT_MESSAGE)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Thinking/)).not.toBeInTheDocument();
+    expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- add a 60s inactivity watchdog to the SSE run-stream client and reset it on `run_event`, `run_complete`, and `heartbeat`
- fall back cleanly on stalled SSE streams without double-triggering fallback paths
- treat polling transport timeout as a soft degradation warning instead of synthesizing a failed assistant message
- add frontend coverage for watchdog expiry/reset/cleanup and for fallback polling timeout semantics
- defer broader degraded-transport UX to follow-up issue #146

## Linked Issue
Closes #130
Refs #146

## Validation
- [ ] `python -m unittest discover -s tests -p "test_*.py" -v`
- [ ] `python tests/run_repo_checks.py`
- [x] `cd frontend && npm test -- --runInBand runStream.test.js sendMessage.test.jsx`
  ```
  PASS tests/runStream.test.js
  PASS tests/sendMessage.test.jsx

  Test Suites: 2 passed, 2 total
  Tests:       27 passed, 27 total
  ```
- [x] `cd frontend && npm test -- --runInBand`
  ```
  PASS tests/sendMessage.test.jsx
  PASS tests/runStream.test.js
  PASS tests/ChatPanel.test.jsx
  PASS tests/DocumentsPanel.test.jsx
  PASS tests/formatters.test.js

  Test Suites: 5 passed, 5 total
  Tests:       51 passed, 51 total
  ```
- No LLM/tool-calling behavior changed; frontend transport/UI behavior only

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [ ] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inactivity watchdog for SSE run streams and soft timeout handling for the polling fallback to improve reliability and avoid false failure messages. Users see a clear warning when live updates stall, and streams cleanly fall back without duplicate triggers. Closes #130; follow-up UX in #146.

- **Bug Fixes**
  - Added a 60s SSE inactivity watchdog (configurable via `inactivityTimeoutMs`, default `DEFAULT_RUN_STREAM_INACTIVITY_TIMEOUT_MS`), reset on `run_event`, `run_complete`, and `heartbeat`; cleared on completion and cleanup.
  - Ensured a single `triggerFallback` path that clears the watchdog and closes the stream to prevent duplicate calls.
  - Introduced `RunTransportTimeoutError` and show `RUN_TRANSPORT_TIMEOUT_MESSAGE` for polling timeouts only in the active conversation, instead of synthesizing a failed assistant message.
  - Improved error propagation with `ensureError`; expanded tests for watchdog expiry/reset/cleanup, heartbeat behavior, soft-timeout UI, and hard-failure cases.

<sup>Written for commit 11243a51f6e73359936b857c0f591729d16e2684. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

