### PR TITLE
fix: suppress hydration warning on body from browser extensions

### DIFF
--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -11,7 +11,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- Added `suppressHydrationWarning` to the `<body>` tag in `frontend/app/layout.js`
- Browser extensions like Grammarly inject `data-new-gr-c-s-check-loaded` and `data-gr-ext-installed` attributes into `<body>` after SSR, causing React hydration mismatches that cannot be patched up
- `suppressHydrationWarning` is the [recommended fix](https://nextjs.org/docs/messages/react-hydration-error) for attributes injected by browser extensions outside our control; it only suppresses the warning one level deep on the element

## Linked Issue
Closes #149

## Validation
- [x] `python -m unittest discover -s tests -p "test_*.py" -v` — no tests affected (frontend-only change)
- [x] `python tests/run_repo_checks.py` — passes
- [ ] No LLM/tool-calling behavior changed

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebased against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `suppressHydrationWarning` to the root `<body>` in `frontend/app/layout.js` to avoid React hydration mismatches from extension-injected attributes after SSR (e.g., Grammarly). Closes #149 by silencing console warnings without changing runtime behavior.

<sup>Written for commit bb4de6d000b10e314df7ca771c2d7b4301df8077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

