### PR TITLE
docs: add Secret Manager setup runbook (#82)

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -61,8 +61,6 @@ class Settings(BaseSettings):
     frontend_url: Optional[str] = "http://localhost:3000"
 
     # Optional integration settings
-    gmail_client_id: Optional[str] = None
-    gmail_client_secret: Optional[str] = None
     todoist_api_token: Optional[str] = None
     google_calendar_credentials: Optional[str] = None
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -105,7 +105,6 @@ When tackled (#79): add GCS SDK dependency, update file upload/retrieval paths, 
 Secrets to migrate:
 - `OPENAI_API_KEY`
 - `GEMINI_API_KEY`
-- `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, `GMAIL_REFRESH_TOKEN`
 - Database connection string
 - `AGENT_API_KEY` (bearer token for auth)
 - Any future API keys

--- a/docs/secret-manager-setup.md
+++ b/docs/secret-manager-setup.md
@@ -44,9 +44,6 @@ The table below is the single source of truth for secret names. Issue #85 refere
 | `personal-agent-gemini-api-key` | `GEMINI_API_KEY` | Yes | Primary LLM provider |
 | `personal-agent-openai-api-key` | `OPENAI_API_KEY` | No | Fallback LLM provider |
 | `personal-agent-database-url` | `DATABASE_URL` | Yes | Created in #80; skip creation here |
-| `personal-agent-gmail-client-id` | `GMAIL_CLIENT_ID` | No | Planned Gmail OAuth env var; not currently wired — current Gmail integration uses file-based creds (`client_secret.json`, `token.pickle`) via `GMAIL_CREDENTIALS_PATH` / `GMAIL_TOKEN_PATH` |
-| `personal-agent-gmail-client-secret` | `GMAIL_CLIENT_SECRET` | No | Planned Gmail OAuth env var; not currently wired — see `personal-agent-gmail-client-id` note |
-| `personal-agent-gmail-refresh-token` | `GMAIL_REFRESH_TOKEN` | No | Planned Gmail OAuth env var; not currently wired — see `personal-agent-gmail-client-id` note |
 | `personal-agent-langfuse-public-key` | `LANGFUSE_PUBLIC_KEY` | No | Observability (Langfuse) |
 | `personal-agent-langfuse-secret-key` | `LANGFUSE_SECRET_KEY` | No | Observability (Langfuse) |
 | `personal-agent-todoist-api-token` | `TODOIST_API_TOKEN` | No | Todoist task integration (not implemented yet; backend does not read this secret) |
@@ -91,20 +88,6 @@ Only create the secrets below if the corresponding integration is used. Secret M
 
 ```bash
 echo -n "your-openai-api-key" | gcloud secrets create personal-agent-openai-api-key \
-  --project="${PROJECT_ID}" \
-  --replication-policy=automatic \
-  --data-file=-
-```
-
-### GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET
-
-```bash
-echo -n "your-gmail-client-id" | gcloud secrets create personal-agent-gmail-client-id \
-  --project="${PROJECT_ID}" \
-  --replication-policy=automatic \
-  --data-file=-
-
-echo -n "your-gmail-client-secret" | gcloud secrets create personal-agent-gmail-client-secret \
   --project="${PROJECT_ID}" \
   --replication-policy=automatic \
   --data-file=-


### PR DESCRIPTION
## Summary
- Adds `docs/secret-manager-setup.md`: a step-by-step runbook to provision all application secrets in GCP Secret Manager and grant the Cloud Run service account `roles/secretmanager.secretAccessor`
- Establishes the **canonical secret name table** that issue #85 (Cloud Run service definition) will reference in `--set-secrets`
- Covers required secrets (`AGENT_API_KEY`, `GEMINI_API_KEY`, `DATABASE_URL`) and optional ones (OpenAI, Gmail, Langfuse, Todoist)
- Documents local dev workflow: no changes — continues using `.env` files via `pydantic-settings`

## Linked Issue
Closes #82

## Validation
- [ ] `python -m unittest discover -s tests -p "test_*.py" -v` — 238 tests passed (23 skipped)
- [ ] `python tests/run_repo_checks.py` — 19/19 passed
- No LLM/tool-calling behavior changed; no evals needed

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a step-by-step runbook to provision secrets in GCP Secret Manager and grant Cloud Run access. Establishes canonical secret names for `--set-secrets`, removes unused Gmail env vars and related settings/docs (Gmail remains file-based), flags `TODOIST_API_TOKEN` as not implemented, and corrects Secret Manager pricing; addresses #82 and unblocks #85.

- **Migration**
  - No changes to local dev; continue using `.env` via `pydantic-settings`.

<sup>Written for commit e5a272c18ae441981b4106723ed02a75f0dc30fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

