### PR TITLE
feat(ops): add GitHub Actions workflow for Cloud Run deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Detect CI-relevant changes
         id: changes
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "push" ]; then
             echo "run_backend_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_frontend_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_repo_checks=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           IMAGE_TAG=${{ env.IMAGE_NAME }}:$SHA
           LATEST_TAG=${{ env.IMAGE_NAME }}:latest
           
-          docker build -t $IMAGE_TAG -t $LATEST_TAG -f Dockerfile .
+          docker build --platform linux/amd64 -t $IMAGE_TAG -t $LATEST_TAG -f Dockerfile .
           docker push $IMAGE_TAG
           docker push $LATEST_TAG
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy Backend to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: pushstart-481717
+  REGION: europe-west2
+  SERVICE_NAME: personal-agent-backend
+  IMAGE_NAME: europe-west2-docker.pkg.dev/pushstart-481717/personal-agent/backend
+
+jobs:
+  deploy:
+    name: Build and Deploy Backend
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and Push Docker image
+        run: |
+          SHA=${{ github.event.workflow_run.head_sha || github.sha }}
+          IMAGE_TAG=${{ env.IMAGE_NAME }}:$SHA
+          LATEST_TAG=${{ env.IMAGE_NAME }}:latest
+          
+          docker build -t $IMAGE_TAG -t $LATEST_TAG -f Dockerfile .
+          docker push $IMAGE_TAG
+          docker push $LATEST_TAG
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          image: ${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Verify SHA is still HEAD of main
+        if: github.event_name == 'workflow_run'
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          git fetch origin main
+          MAIN_HEAD=$(git rev-parse origin/main)
+          if [ "$HEAD_SHA" != "$MAIN_HEAD" ]; then
+            echo "Skipping deploy: triggering SHA ($HEAD_SHA) is no longer HEAD of main ($MAIN_HEAD)."
+            # Exit successfully to not show a red X, but skip the rest of the deploy
+            exit 0
+          fi
 
       - name: Google Auth
         id: auth
@@ -67,10 +81,28 @@ jobs:
           image: ${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Verify Deployment
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
         run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" ${{ steps.deploy.outputs.url }}/api/v1/health)
-          if [ "$HTTP_STATUS" != "401" ] && [ "$HTTP_STATUS" != "200" ]; then
-            echo "Health check failed with status $HTTP_STATUS"
-            exit 1
-          fi
-          echo "Deployment verified. Health check returned expected status ($HTTP_STATUS)."
+          MAX_RETRIES=5
+          INITIAL_DELAY=5
+          
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" $SERVICE_URL/api/v1/health || echo "000")
+            
+            if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "401" ]; then
+              echo "Deployment verified. Health check returned expected status ($HTTP_STATUS)."
+              exit 0
+            fi
+            
+            echo "Health check attempt $attempt/$MAX_RETRIES failed with status $HTTP_STATUS"
+            
+            if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+              SLEEP_SECONDS=$((INITIAL_DELAY * attempt))
+              echo "Retrying in ${SLEEP_SECONDS}s..."
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
+          
+          echo "Health check failed after $MAX_RETRIES attempts. Last status: $HTTP_STATUS"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-${{ github.workflow }}-${{ github.ref_name }}
+  group: deploy-${{ github.workflow }}-${{ env.SERVICE_NAME }}-${{ env.REGION }}
   cancel-in-progress: false
 
 env:
@@ -24,7 +24,7 @@ env:
 jobs:
   deploy:
     name: Build and Deploy Backend
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,16 +10,16 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: deploy-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  PROJECT_ID: pushstart-481717
   REGION: europe-west2
   SERVICE_NAME: personal-agent-backend
-  IMAGE_NAME: europe-west2-docker.pkg.dev/${{ env.PROJECT_ID }}/personal-agent/backend
+  IMAGE_NAME: europe-west2-docker.pkg.dev/pushstart-481717/personal-agent/backend
 
 jobs:
   deploy:
@@ -37,7 +37,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -58,8 +59,18 @@ jobs:
           docker push $LATEST_TAG
 
       - name: Deploy to Cloud Run
+        id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.REGION }}
           image: ${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Verify Deployment
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" ${{ steps.deploy.outputs.url }}/api/v1/health)
+          if [ "$HTTP_STATUS" != "401" ] && [ "$HTTP_STATUS" != "200" ]; then
+            echo "Health check failed with status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "Deployment verified. Health check returned expected status ($HTTP_STATUS)."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify SHA is still HEAD of main
+        id: verify_sha
         if: github.event_name == 'workflow_run'
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -43,11 +44,13 @@ jobs:
           MAIN_HEAD=$(git rev-parse origin/main)
           if [ "$HEAD_SHA" != "$MAIN_HEAD" ]; then
             echo "Skipping deploy: triggering SHA ($HEAD_SHA) is no longer HEAD of main ($MAIN_HEAD)."
-            # Exit successfully to not show a red X, but skip the rest of the deploy
-            exit 0
+            echo "continue=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "continue=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Google Auth
+        if: steps.verify_sha.outputs.continue != 'false'
         id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -55,12 +58,15 @@ jobs:
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
+        if: steps.verify_sha.outputs.continue != 'false'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Configure Docker for Artifact Registry
+        if: steps.verify_sha.outputs.continue != 'false'
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build and Push Docker image
+        if: steps.verify_sha.outputs.continue != 'false'
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
@@ -73,6 +79,7 @@ jobs:
           docker push $LATEST_TAG
 
       - name: Deploy to Cloud Run
+        if: steps.verify_sha.outputs.continue != 'false'
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
@@ -81,6 +88,7 @@ jobs:
           image: ${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Verify Deployment
+        if: steps.verify_sha.outputs.continue != 'false'
         env:
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
         run: |
@@ -88,7 +96,7 @@ jobs:
           INITIAL_DELAY=5
           
           for attempt in $(seq 1 "$MAX_RETRIES"); do
-            HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" $SERVICE_URL/api/v1/health || echo "000")
+            HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" "$SERVICE_URL/api/v1/health" || echo "000")
             
             if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "401" ]; then
               echo "Deployment verified. Health check returned expected status ($HTTP_STATUS)."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,20 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: deploy-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 env:
-  REGION: europe-west2
+  REGION: ${{ vars.GCP_REGION || 'europe-west2' }}
   SERVICE_NAME: personal-agent-backend
-  IMAGE_NAME: europe-west2-docker.pkg.dev/pushstart-481717/personal-agent/backend
+  IMAGE_NAME: ${{ vars.GCP_REGION || 'europe-west2' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/personal-agent/backend
 
 jobs:
   deploy:
     name: Build and Deploy Backend
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Checkout
@@ -101,7 +102,7 @@ jobs:
             else
               AUTH_HEADER="X-Dummy: dummy"
             fi
-            if ! HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" "$SERVICE_URL/api/v1/health"); then
+            if ! HTTP_STATUS=$(curl -s --connect-timeout 5 --max-time 10 -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" "$SERVICE_URL/api/v1/health"); then
               echo "curl command failed (network/DNS/timeout error)"
               HTTP_STATUS="000"
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,18 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PROJECT_ID: pushstart-481717
   REGION: europe-west2
   SERVICE_NAME: personal-agent-backend
-  IMAGE_NAME: europe-west2-docker.pkg.dev/pushstart-481717/personal-agent/backend
+  IMAGE_NAME: europe-west2-docker.pkg.dev/${{ env.PROJECT_ID }}/personal-agent/backend
 
 jobs:
   deploy:
@@ -39,10 +46,12 @@ jobs:
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build and Push Docker image
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
-          SHA=${{ github.event.workflow_run.head_sha || github.sha }}
-          IMAGE_TAG=${{ env.IMAGE_NAME }}:$SHA
-          LATEST_TAG=${{ env.IMAGE_NAME }}:latest
+          SHA=$HEAD_SHA
+          IMAGE_TAG=${IMAGE_NAME}:$SHA
+          LATEST_TAG=${IMAGE_NAME}:latest
           
           docker build --platform linux/amd64 -t $IMAGE_TAG -t $LATEST_TAG -f Dockerfile .
           docker push $IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: deploy-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   REGION: europe-west2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  group: deploy-${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -32,7 +32,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 0
 
       - name: Verify SHA is still HEAD of main
         id: verify_sha
@@ -91,15 +90,27 @@ jobs:
         if: steps.verify_sha.outputs.continue != 'false'
         env:
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
         run: |
           MAX_RETRIES=5
           INITIAL_DELAY=5
           
           for attempt in $(seq 1 "$MAX_RETRIES"); do
-            HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" "$SERVICE_URL/api/v1/health" || echo "000")
+            if [ -n "$AGENT_API_KEY" ]; then
+              AUTH_HEADER="Authorization: Bearer $AGENT_API_KEY"
+            else
+              AUTH_HEADER="X-Dummy: dummy"
+            fi
+            if ! HTTP_STATUS=$(curl -sS --connect-timeout 5 --max-time 10 -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" "$SERVICE_URL/api/v1/health"); then
+              echo "curl command failed (network/DNS/timeout error)"
+              HTTP_STATUS="000"
+            fi
             
-            if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "401" ]; then
+            if [ "$HTTP_STATUS" = "200" ]; then
               echo "Deployment verified. Health check returned expected status ($HTTP_STATUS)."
+              exit 0
+            elif [ "$HTTP_STATUS" = "401" ] && [ -z "$AGENT_API_KEY" ]; then
+              echo "Deployment verified. Service is up and requires authentication, but no AGENT_API_KEY was provided to the workflow."
               exit 0
             fi
             


### PR DESCRIPTION
## Summary
- Added `.github/workflows/deploy.yml` workflow for backend deployment to Cloud Run.
- The workflow triggers on the successful completion of the `CI` workflow on the `main` branch.
- It builds the backend Docker image, pushes it to Google Artifact Registry, and deploys it to the `personal-agent-backend` Cloud Run service.

## Linked Issue
Refs #86

## Validation
- [x] `python tests/run_repo_checks.py`

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates backend deployment to Cloud Run via a GitHub Actions workflow. Builds and pushes Docker images to Artifact Registry, deploys `personal-agent-backend` after CI passes on `main` or via manual run on `main`, and verifies the rollout with retries. Implements #86.

- **New Features**
  - Adds `.github/workflows/deploy.yml` triggered after successful `CI` on `main` or `workflow_dispatch` on `main`; uses a concurrency group scoped by workflow+service+region with `cancel-in-progress: false`, a 15‑min timeout, and a guard to skip stale runs (triggering SHA no longer `main` HEAD).
  - Uses Workload Identity Federation for GCP auth; builds a `linux/amd64` image tagged with commit SHA and `latest`, and pushes to `${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/personal-agent/backend` (config via repo vars; default `europe-west2`).
  - Deploys to Cloud Run `personal-agent-backend` and verifies `/api/v1/health` (200, or 401 when no `AGENT_API_KEY`) with retry/backoff; updates `ci.yml` to also run on `push` to `main` and run all tests on pushes.

<sup>Written for commit 2368d5c7d757bcde6eca77b7b563c1d23c38ca95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

