### PR TITLE
fix(hooks): allow opencode prefix in pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,8 +7,8 @@ if [ "$BRANCH" = "main" ]; then
   exit 1
 fi
 
-if ! echo "$BRANCH" | grep -Eq '^(codex|claude)/[a-z0-9][a-z0-9-]*/[0-9]+-[a-z0-9][a-z0-9-]*$'; then
-  echo "Push blocked: branch must match <agent>/<type>/<issue>-<slug> (e.g. codex/fix/7-safe-calculator)."
+if ! echo "$BRANCH" | grep -Eq '^(codex|claude|opencode)/[a-z0-9][a-z0-9-]*/[0-9]+-[a-z0-9][a-z0-9-]*$'; then
+  echo "Push blocked: branch must match <agent>/<type>/<issue>-<slug> (e.g. opencode/fix/7-safe-calculator)."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Updates `.githooks/pre-push` to allow the `opencode` prefix in branch names, as it was previously only allowing `codex` and `claude`.

## Linked Issue
Refs #59

## Validation
- [x] `python -m unittest discover -s tests -p "test_*.py" -v`
- [x] `python tests/run_repo_checks.py`

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebasing done against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the `opencode` prefix in `.githooks/pre-push` branch name validation and update the error example. This unblocks pushes from branches like `opencode/fix/59-allow-opencode-prepush` and aligns with issue #59.

<sup>Written for commit 09330953f802bc0396e90a8ee2fa7d0cb93662bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

