### PR TITLE
feat(frontend): Tools tab in right panel with Gmail integration management

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -89,6 +89,13 @@ class ToolInfo(BaseModel):
     description: str = Field(..., description="Tool description")
 
 
+class ToolInfoWithStatus(BaseModel):
+    """Tool info including active/inactive status."""
+    name: str = Field(..., description="Tool name")
+    description: str = Field(..., description="Tool description")
+    active: bool = Field(..., description="Whether tool is currently active")
+
+
 class GmailConnectionStatusResponse(BaseModel):
     """Status for the Gmail integration connection."""
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -89,10 +89,8 @@ class ToolInfo(BaseModel):
     description: str = Field(..., description="Tool description")
 
 
-class ToolInfoWithStatus(BaseModel):
+class ToolInfoWithStatus(ToolInfo):
     """Tool info including active/inactive status."""
-    name: str = Field(..., description="Tool name")
-    description: str = Field(..., description="Tool description")
     active: bool = Field(..., description="Whether tool is currently active")
 
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -195,7 +195,7 @@ async def get_all_tools_info():
         try:
             tools = await offload_blocking_call(orchestrator.tool_registry.get_tool_info)
             update_observation(observation, output={"tool_count": len(tools)})
-            return tools
+            return [ToolInfoWithStatus(**tool) for tool in tools]
         except Exception as e:
             logger.error(f"Error getting tools info: {str(e)}")
             raise HTTPException(status_code=500, detail="Failed to retrieve tools info")

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, UploadFile, File, Query
 from fastapi.responses import RedirectResponse
 from backend.api.models import (
     ConversationCreate, ConversationResponse,
-    MessageResponse, ToolInfo, HealthResponse, DocumentUploadResponse,
+    MessageResponse, ToolInfo, ToolInfoWithStatus, HealthResponse, DocumentUploadResponse,
     DocumentListResponse, DocumentDeleteResponse, DocumentInfo,
     ObservabilitySummaryResponse,
     TitleGenerationResponse,
@@ -177,6 +177,24 @@ async def get_available_tools():
         except Exception as e:
             logger.error(f"Error getting tools: {str(e)}")
             raise HTTPException(status_code=500, detail="Failed to retrieve available tools")
+
+
+@router.get("/tools/info", response_model=List[ToolInfoWithStatus])
+async def get_all_tools_info():
+    """Get all tools with active/inactive status."""
+    with observe_operation(
+        name="api.tools.info",
+        counter_prefix="api.tools.info",
+        as_type="span",
+        metadata={"component": "api", "endpoint": "/api/v1/tools/info"},
+    ) as observation:
+        try:
+            tools = await offload_blocking_call(orchestrator.tool_registry.get_tool_info)
+            update_observation(observation, output={"tool_count": len(tools)})
+            return tools
+        except Exception as e:
+            logger.error(f"Error getting tools info: {str(e)}")
+            raise HTTPException(status_code=500, detail="Failed to retrieve tools info")
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -181,7 +181,11 @@ async def get_available_tools():
 
 @router.get("/tools/info", response_model=List[ToolInfoWithStatus])
 async def get_all_tools_info():
-    """Get all tools with active/inactive status."""
+    """Get all tools with active/inactive status.
+
+    Note: active status is evaluated against the shared orchestrator's user_id
+    (single-user deployment). Consistent with the existing GET /tools endpoint.
+    """
     with observe_operation(
         name="api.tools.info",
         counter_prefix="api.tools.info",

--- a/backend/integrations/gmail_oauth.py
+++ b/backend/integrations/gmail_oauth.py
@@ -159,6 +159,11 @@ def create_connect_url(*, user_id: str, return_to: Optional[str]) -> str:
         expires_at=expires_at,
     )
     flow = _build_flow(state=state)
+    # Note: `include_granted_scopes` is intentionally omitted. When set to "true",
+    # Google merges scopes from other active OAuth sessions (e.g. the NextAuth login
+    # session) into the response. google-auth-oauthlib then rejects the callback
+    # because the returned scopes don't match the requested ones. Omitting it ensures
+    # the response contains only the scopes explicitly requested here (gmail.readonly).
     authorization_url, _ = flow.authorization_url(
         access_type="offline",
         prompt="consent",

--- a/backend/integrations/gmail_oauth.py
+++ b/backend/integrations/gmail_oauth.py
@@ -161,7 +161,6 @@ def create_connect_url(*, user_id: str, return_to: Optional[str]) -> str:
     flow = _build_flow(state=state)
     authorization_url, _ = flow.authorization_url(
         access_type="offline",
-        include_granted_scopes="true",
         prompt="consent",
     )
     return authorization_url

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -263,6 +263,7 @@ class ToolRegistry:
         # Snapshot items before calling get_available_tools() so that any
         # _sync_gmail_tool() mutation during refresh_runtime_capabilities()
         # doesn't cause a concurrent modification during iteration.
+        # Broader thread-safety (concurrent threads) is tracked in issue #213.
         all_items = list(self._tools.items())
         active_tool_names = {tool.name for tool in self.get_available_tools()}
         return [

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -256,7 +256,10 @@ class ToolRegistry:
         return list(self._tools.keys())
     
     def get_tool_info(self) -> List[Dict[str, Any]]:
-        """Get information about all registered tools."""
+        """Get information about all registered tools including active status.
+
+        Returns a list of dicts with keys: name (str), description (str), active (bool).
+        """
         active_tool_names = {tool.name for tool in self.get_available_tools()}
         return [
             {

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -260,12 +260,11 @@ class ToolRegistry:
 
         Returns a list of dicts with keys: name (str), description (str), active (bool).
         """
-        # Snapshot items before calling get_available_tools() so that any
-        # _sync_gmail_tool() mutation during refresh_runtime_capabilities()
-        # doesn't cause a concurrent modification during iteration.
+        active_tool_names = {tool.name for tool in self.get_available_tools()}
+        # Snapshot after get_available_tools() so the list reflects any
+        # _sync_gmail_tool() mutations that just occurred (e.g. gmail_read becoming active).
         # Broader thread-safety (concurrent threads) is tracked in issue #213.
         all_items = list(self._tools.items())
-        active_tool_names = {tool.name for tool in self.get_available_tools()}
         return [
             {
                 "name": name,

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -255,7 +255,7 @@ class ToolRegistry:
         """Get list of all registered tool names."""
         return list(self._tools.keys())
     
-    def get_tool_info(self) -> List[Dict[str, str]]:
+    def get_tool_info(self) -> List[Dict[str, Any]]:
         """Get information about all registered tools."""
         active_tool_names = {tool.name for tool in self.get_available_tools()}
         return [

--- a/backend/orchestrator/tool_registry.py
+++ b/backend/orchestrator/tool_registry.py
@@ -260,6 +260,10 @@ class ToolRegistry:
 
         Returns a list of dicts with keys: name (str), description (str), active (bool).
         """
+        # Snapshot items before calling get_available_tools() so that any
+        # _sync_gmail_tool() mutation during refresh_runtime_capabilities()
+        # doesn't cause a concurrent modification during iteration.
+        all_items = list(self._tools.items())
         active_tool_names = {tool.name for tool in self.get_available_tools()}
         return [
             {
@@ -267,5 +271,5 @@ class ToolRegistry:
                 "description": getattr(tool, 'description', 'No description available'),
                 "active": name in active_tool_names,
             }
-            for name, tool in list(self._tools.items())
+            for name, tool in all_items
         ]

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1444,3 +1444,4 @@ button {
 .gmail-connect-button { padding: 9px 14px; font-size: 13px; }
 .gmail-disconnect-button { padding: 9px 14px; font-size: 13px; background: rgba(110, 20, 29, 0.35); border-color: rgba(255, 109, 115, 0.32); color: #ffd7d9; }
 .gmail-disconnect-button:hover { background: rgba(155, 30, 42, 0.48); }
+

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1400,3 +1400,47 @@ button {
 *::-webkit-scrollbar-track {
   background: rgba(10, 35, 52, 0.36);
 }
+
+/* Right panel tab bar */
+.right-panel-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 12px;
+  background: rgba(10, 29, 43, 0.72);
+  border: 1px solid rgba(116, 178, 255, 0.14);
+}
+.right-panel-tab {
+  flex: 1;
+  border-radius: 9px;
+  padding: 8px 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  background: transparent;
+  transition: background 120ms ease, color 120ms ease;
+  border: none;
+}
+.right-panel-tab.active {
+  color: var(--text-primary);
+  background: rgba(23, 57, 82, 0.95);
+}
+
+/* Tools panel */
+.tools-panel-body { padding: 0 14px 14px; overflow-y: auto; display: grid; gap: 12px; }
+.tool-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 12px; border-radius: 12px; background: rgba(12, 37, 56, 0.7); font-size: 13px; }
+.tool-name { font-weight: 700; color: var(--text-primary); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tool-badge { flex: none; border-radius: 999px; padding: 4px 8px; font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.tool-badge.active { color: #baf7cc; background: rgba(28, 79, 47, 0.34); border: 1px solid rgba(94, 241, 150, 0.28); }
+.tool-badge.inactive { color: var(--text-muted); background: rgba(18, 46, 66, 0.7); border: 1px solid rgba(109, 145, 166, 0.24); }
+
+/* Gmail card */
+.gmail-card { border-radius: 14px; border: 1px solid rgba(109, 145, 166, 0.24); background: rgba(12, 37, 56, 0.52); padding: 14px; display: grid; gap: 10px; }
+.gmail-card-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.gmail-card-label { font-size: 13px; font-weight: 700; color: var(--text-primary); }
+.gmail-card-account { font-size: 12px; color: var(--text-muted); }
+.gmail-card-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.gmail-connect-button { padding: 9px 14px; font-size: 13px; }
+.gmail-disconnect-button { padding: 9px 14px; font-size: 13px; background: rgba(110, 20, 29, 0.35); border-color: rgba(255, 109, 115, 0.32); color: #ffd7d9; }
+.gmail-disconnect-button:hover { background: rgba(155, 30, 42, 0.48); }

--- a/frontend/components/DocumentsPanel.jsx
+++ b/frontend/components/DocumentsPanel.jsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import {
   formatDocumentStatusLabel,
   formatFileSize,
   formatRelativeTime,
   truncateText,
 } from "@/lib/formatters";
+import ToolsDashboard from "@/components/ToolsDashboard";
 
 const DOCUMENT_STATUS_CLASSNAMES = new Set(["completed", "processing", "pending", "failed"]);
 
@@ -35,6 +37,7 @@ export default function DocumentsPanel({
   onDeleteDocument,
   fileInputRef,
 }) {
+  const [activeTab, setActiveTab] = useState("context");
   const selectedCount = selectedDocuments.size;
   const readyDocuments = documents.filter((doc) => doc.processed === "completed");
   const readyCount = readyDocuments.length;
@@ -78,13 +81,25 @@ export default function DocumentsPanel({
       {!isCollapsed && (
         <>
           <div className="panel-header">
-            <p className="eyebrow">Context</p>
-            <h2>Workspace Sidebar</h2>
+            <div className="right-panel-tabs">
+              <button
+                type="button"
+                className={`right-panel-tab ${activeTab === "context" ? "active" : ""}`}
+                onClick={() => setActiveTab("context")}
+              >
+                Context
+              </button>
+              <button
+                type="button"
+                className={`right-panel-tab ${activeTab === "tools" ? "active" : ""}`}
+                onClick={() => setActiveTab("tools")}
+              >
+                Tools
+              </button>
+            </div>
           </div>
-          <p className="panel-note context-panel-note">
-            Keep chat context, uploaded files, and future sidebar tools together in one place.
-          </p>
 
+          {activeTab === "context" && (
           <section className="context-section">
             <button
               type="button"
@@ -230,6 +245,9 @@ export default function DocumentsPanel({
               </>
             )}
           </section>
+          )}
+
+          {activeTab === "tools" && <ToolsDashboard />}
         </>
       )}
     </aside>

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -73,8 +73,11 @@ export default function ToolsDashboard() {
     } catch (err) {
       setGmailError(err?.message ?? "Failed to disconnect Gmail");
     } finally {
-      await fetchTools();
-      setGmailLoading(false);
+      try {
+        await fetchTools();
+      } finally {
+        setGmailLoading(false);
+      }
     }
   }
 

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -29,6 +29,7 @@ export default function ToolsDashboard() {
       const status = await apiCall("/gmail/status");
       setGmailStatus(status);
     } catch (err) {
+      setGmailStatus(null);
       setGmailError(err?.message ?? "Failed to load Gmail status");
     } finally {
       setGmailLoading(false);

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -55,9 +55,13 @@ export default function ToolsDashboard() {
   function handleGmailConnect() {
     // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
     // Add any new deployment URLs there before enabling Gmail connect on that host.
-    const returnTo = new URL(window.location.href).toString();
+    // Only forward the ?conversation= param (if present) so the active chat is restored
+    // after the OAuth round-trip without leaking arbitrary query params through the flow.
+    const returnTo = new URL(window.location.pathname, window.location.origin);
+    const conversationId = new URLSearchParams(window.location.search).get("conversation");
+    if (conversationId) returnTo.searchParams.set("conversation", conversationId);
     // Full browser navigation required — OAuth flow must follow redirects, not fetch.
-    window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
+    window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo.toString())}`;
   }
 
   async function handleGmailDisconnect() {
@@ -66,10 +70,10 @@ export default function ToolsDashboard() {
     try {
       const status = await apiCall("/gmail/connection", { method: "DELETE" });
       setGmailStatus(status);
-      await fetchTools();
     } catch (err) {
       setGmailError(err?.message ?? "Failed to disconnect Gmail");
     } finally {
+      await fetchTools();
       setGmailLoading(false);
     }
   }
@@ -123,7 +127,7 @@ export default function ToolsDashboard() {
                 onClick={handleGmailConnect}
                 disabled={!gmailStatus.ready}
                 title={
-                  !gmailStatus?.ready ? gmailStatus?.reasons?.join("; ") ?? "Gmail not configured" : undefined
+                  !gmailStatus?.ready ? gmailStatus?.reasons?.join("; ") || "Gmail not configured" : undefined
                 }
               >
                 Connect Gmail

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -48,6 +48,8 @@ export default function ToolsDashboard() {
   }, []);
 
   function handleGmailConnect() {
+    // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
+    // Add any new deployment URLs there before enabling Gmail connect on that host.
     const returnTo = window.location.origin + window.location.pathname;
     window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
   }

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -12,7 +12,7 @@ export default function ToolsDashboard() {
   const fetchTools = useCallback(async () => {
     try {
       const tools = await apiCall("/tools/info");
-      setAllTools([...tools].sort((a, b) => a.name.localeCompare(b.name)));
+      setAllTools(tools.sort((a, b) => a.name.localeCompare(b.name)));
     } catch (err) {
       console.error("Failed to load tools list:", err);
       setToolsError(err?.message ?? "Failed to load tools");
@@ -62,6 +62,7 @@ export default function ToolsDashboard() {
     try {
       const status = await apiCall("/gmail/connection", { method: "DELETE" });
       setGmailStatus(status);
+      fetchTools();
     } catch (err) {
       setGmailError(err?.message ?? "Failed to disconnect Gmail");
     } finally {
@@ -135,7 +136,7 @@ export default function ToolsDashboard() {
           </div>
         )}
 
-        {!gmailLoading && gmailStatus?.reasons?.length > 0 && (
+        {!gmailLoading && gmailStatus?.reasons?.filter(Boolean).length > 0 && (
           <p className="panel-note" style={{ fontSize: "11px", marginTop: 0 }}>
             {gmailStatus.reasons.join(" · ")}
           </p>

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -53,6 +53,7 @@ export default function ToolsDashboard() {
     // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
     // Add any new deployment URLs there before enabling Gmail connect on that host.
     const returnTo = window.location.origin + window.location.pathname;
+    // Full browser navigation required — OAuth flow must follow redirects, not fetch.
     window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
   }
 
@@ -119,7 +120,7 @@ export default function ToolsDashboard() {
                 onClick={handleGmailConnect}
                 disabled={!gmailStatus.ready}
                 title={
-                  !gmailStatus.ready ? gmailStatus.reasons?.join("; ") ?? "Gmail not configured" : undefined
+                  !gmailStatus.ready ? gmailStatus?.reasons?.join("; ") ?? "Gmail not configured" : undefined
                 }
               >
                 Connect Gmail
@@ -136,7 +137,7 @@ export default function ToolsDashboard() {
           </div>
         )}
 
-        {!gmailLoading && gmailStatus?.reasons?.filter(Boolean).length > 0 && (
+        {!gmailLoading && gmailStatus?.reasons?.some(Boolean) && (
           <p className="panel-note" style={{ fontSize: "11px", marginTop: 0 }}>
             {gmailStatus.reasons.join(" · ")}
           </p>

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -1,0 +1,138 @@
+import { useState, useEffect } from "react";
+import { apiCall } from "@/lib/api";
+
+export default function ToolsDashboard() {
+  const [allTools, setAllTools] = useState([]);
+  const [gmailStatus, setGmailStatus] = useState(null);
+  const [toolsLoading, setToolsLoading] = useState(true);
+  const [gmailLoading, setGmailLoading] = useState(true);
+  const [gmailError, setGmailError] = useState(null);
+
+  async function fetchTools() {
+    try {
+      const tools = await apiCall("/tools/info");
+      setAllTools(tools);
+    } catch {
+      // silently ignore — tools list is best-effort
+    } finally {
+      setToolsLoading(false);
+    }
+  }
+
+  async function fetchGmailStatus() {
+    setGmailLoading(true);
+    setGmailError(null);
+    try {
+      const status = await apiCall("/gmail/status");
+      setGmailStatus(status);
+    } catch (err) {
+      setGmailError(err?.message ?? "Failed to load Gmail status");
+    } finally {
+      setGmailLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // Detect ?gmail=connected after OAuth redirect
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("gmail") === "connected") {
+      params.delete("gmail");
+      const newSearch = params.toString();
+      const newUrl =
+        window.location.pathname + (newSearch ? `?${newSearch}` : "") + window.location.hash;
+      window.history.replaceState(null, "", newUrl);
+    }
+
+    fetchTools();
+    fetchGmailStatus();
+  }, []);
+
+  function handleGmailConnect() {
+    const returnTo = window.location.origin + window.location.pathname;
+    window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
+  }
+
+  async function handleGmailDisconnect() {
+    setGmailLoading(true);
+    try {
+      await apiCall("/gmail/connection", { method: "DELETE" });
+    } catch (err) {
+      setGmailError(err?.message ?? "Failed to disconnect Gmail");
+    } finally {
+      fetchGmailStatus();
+    }
+  }
+
+  return (
+    <div className="tools-panel-body">
+      {/* All tools list */}
+      <section>
+        {toolsLoading && <p className="panel-note">Loading tools...</p>}
+        {!toolsLoading &&
+          allTools.map((tool) => (
+            <div key={tool.name} className="tool-row">
+              <span className="tool-name" title={tool.description}>
+                {tool.name}
+              </span>
+              <span className={`tool-badge ${tool.active ? "active" : "inactive"}`}>
+                {tool.active ? "Active" : "Inactive"}
+              </span>
+            </div>
+          ))}
+      </section>
+
+      {/* Gmail integration card */}
+      <div className="gmail-card">
+        <div className="gmail-card-header">
+          <span className="gmail-card-label">Gmail</span>
+          {gmailStatus?.connected && gmailStatus?.account_label && (
+            <span className="gmail-card-account">{gmailStatus.account_label}</span>
+          )}
+        </div>
+
+        {gmailLoading && <p className="panel-note">Loading...</p>}
+        {!gmailLoading && gmailError && <p className="panel-error">{gmailError}</p>}
+
+        {!gmailLoading && !gmailError && gmailStatus && (
+          <div className="gmail-card-actions">
+            {gmailStatus.connected ? (
+              <button
+                type="button"
+                className="secondary-button gmail-disconnect-button"
+                onClick={handleGmailDisconnect}
+              >
+                Disconnect
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="primary-button gmail-connect-button"
+                onClick={handleGmailConnect}
+                disabled={!gmailStatus.ready}
+                title={
+                  !gmailStatus.ready ? gmailStatus.reasons?.join("; ") ?? "Gmail not configured" : undefined
+                }
+              >
+                Connect Gmail
+              </button>
+            )}
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={fetchGmailStatus}
+              aria-label="Refresh Gmail status"
+            >
+              Refresh
+            </button>
+          </div>
+        )}
+
+        {!gmailLoading && gmailStatus?.reasons?.length > 0 && (
+          <p className="panel-note" style={{ fontSize: "11px", marginTop: 0 }}>
+            {gmailStatus.reasons.join(" · ")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -54,11 +54,7 @@ export default function ToolsDashboard() {
   function handleGmailConnect() {
     // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
     // Add any new deployment URLs there before enabling Gmail connect on that host.
-    const returnTo =
-      window.location.origin +
-      window.location.pathname +
-      window.location.search +
-      window.location.hash;
+    const returnTo = new URL(window.location.href).toString();
     // Full browser navigation required — OAuth flow must follow redirects, not fetch.
     window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
   }

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { apiCall } from "@/lib/api";
 
 export default function ToolsDashboard() {
@@ -9,7 +9,7 @@ export default function ToolsDashboard() {
   const [gmailLoading, setGmailLoading] = useState(true);
   const [gmailError, setGmailError] = useState(null);
 
-  async function fetchTools() {
+  const fetchTools = useCallback(async () => {
     try {
       const tools = await apiCall("/tools/info");
       setAllTools([...tools].sort((a, b) => a.name.localeCompare(b.name)));
@@ -19,9 +19,9 @@ export default function ToolsDashboard() {
     } finally {
       setToolsLoading(false);
     }
-  }
+  }, []);
 
-  async function fetchGmailStatus() {
+  const fetchGmailStatus = useCallback(async () => {
     setGmailLoading(true);
     setGmailError(null);
     try {
@@ -32,10 +32,8 @@ export default function ToolsDashboard() {
     } finally {
       setGmailLoading(false);
     }
-  }
+  }, []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchTools and fetchGmailStatus only
-  // reference stable setter functions; re-declaring them in deps would cause double-fetch on mount
   useEffect(() => {
     // Detect ?gmail=connected after OAuth redirect
     const params = new URLSearchParams(window.location.search);
@@ -49,7 +47,7 @@ export default function ToolsDashboard() {
 
     fetchTools();
     fetchGmailStatus();
-  }, []);
+  }, [fetchTools, fetchGmailStatus]);
 
   function handleGmailConnect() {
     // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
@@ -79,6 +77,7 @@ export default function ToolsDashboard() {
         {!toolsLoading && toolsError && <p className="panel-error">{toolsError}</p>}
         {!toolsLoading && !toolsError &&
           allTools.map((tool) => (
+            // tool.name is unique — the registry uses a dict keyed by name
             <div key={tool.name} className="tool-row">
               <span className="tool-name" title={tool.description}>
                 {tool.name}

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -32,6 +32,8 @@ export default function ToolsDashboard() {
     }
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchTools and fetchGmailStatus only
+  // reference stable setter functions; re-declaring them in deps would cause double-fetch on mount
   useEffect(() => {
     // Detect ?gmail=connected after OAuth redirect
     const params = new URLSearchParams(window.location.search);
@@ -56,6 +58,7 @@ export default function ToolsDashboard() {
 
   async function handleGmailDisconnect() {
     setGmailLoading(true);
+    setGmailError(null);
     try {
       await apiCall("/gmail/connection", { method: "DELETE" });
     } catch (err) {

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -12,8 +12,8 @@ export default function ToolsDashboard() {
     try {
       const tools = await apiCall("/tools/info");
       setAllTools(tools);
-    } catch {
-      // silently ignore — tools list is best-effort
+    } catch (err) {
+      console.error("Failed to load tools list:", err);
     } finally {
       setToolsLoading(false);
     }

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -11,7 +11,7 @@ export default function ToolsDashboard() {
   async function fetchTools() {
     try {
       const tools = await apiCall("/tools/info");
-      setAllTools(tools);
+      setAllTools([...tools].sort((a, b) => a.name.localeCompare(b.name)));
     } catch (err) {
       console.error("Failed to load tools list:", err);
     } finally {

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -60,11 +60,12 @@ export default function ToolsDashboard() {
     setGmailLoading(true);
     setGmailError(null);
     try {
-      await apiCall("/gmail/connection", { method: "DELETE" });
+      const status = await apiCall("/gmail/connection", { method: "DELETE" });
+      setGmailStatus(status);
     } catch (err) {
       setGmailError(err?.message ?? "Failed to disconnect Gmail");
     } finally {
-      fetchGmailStatus();
+      setGmailLoading(false);
     }
   }
 

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -5,6 +5,7 @@ export default function ToolsDashboard() {
   const [allTools, setAllTools] = useState([]);
   const [gmailStatus, setGmailStatus] = useState(null);
   const [toolsLoading, setToolsLoading] = useState(true);
+  const [toolsError, setToolsError] = useState(null);
   const [gmailLoading, setGmailLoading] = useState(true);
   const [gmailError, setGmailError] = useState(null);
 
@@ -14,6 +15,7 @@ export default function ToolsDashboard() {
       setAllTools([...tools].sort((a, b) => a.name.localeCompare(b.name)));
     } catch (err) {
       console.error("Failed to load tools list:", err);
+      setToolsError(err?.message ?? "Failed to load tools");
     } finally {
       setToolsLoading(false);
     }
@@ -74,7 +76,8 @@ export default function ToolsDashboard() {
       {/* All tools list */}
       <section>
         {toolsLoading && <p className="panel-note">Loading tools...</p>}
-        {!toolsLoading &&
+        {!toolsLoading && toolsError && <p className="panel-error">{toolsError}</p>}
+        {!toolsLoading && !toolsError &&
           allTools.map((tool) => (
             <div key={tool.name} className="tool-row">
               <span className="tool-name" title={tool.description}>

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -69,7 +69,7 @@ export default function ToolsDashboard() {
     try {
       const status = await apiCall("/gmail/connection", { method: "DELETE" });
       setGmailStatus(status);
-      fetchTools();
+      await fetchTools();
     } catch (err) {
       setGmailError(err?.message ?? "Failed to disconnect Gmail");
     } finally {

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -122,7 +122,7 @@ export default function ToolsDashboard() {
                 onClick={handleGmailConnect}
                 disabled={!gmailStatus.ready}
                 title={
-                  !gmailStatus.ready ? gmailStatus?.reasons?.join("; ") ?? "Gmail not configured" : undefined
+                  !gmailStatus?.ready ? gmailStatus?.reasons?.join("; ") ?? "Gmail not configured" : undefined
                 }
               >
                 Connect Gmail

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -10,6 +10,7 @@ export default function ToolsDashboard() {
   const [gmailError, setGmailError] = useState(null);
 
   const fetchTools = useCallback(async () => {
+    setToolsLoading(true);
     setToolsError(null);
     try {
       const tools = await apiCall("/tools/info");

--- a/frontend/components/ToolsDashboard.jsx
+++ b/frontend/components/ToolsDashboard.jsx
@@ -10,6 +10,7 @@ export default function ToolsDashboard() {
   const [gmailError, setGmailError] = useState(null);
 
   const fetchTools = useCallback(async () => {
+    setToolsError(null);
     try {
       const tools = await apiCall("/tools/info");
       setAllTools(tools.sort((a, b) => a.name.localeCompare(b.name)));
@@ -52,7 +53,11 @@ export default function ToolsDashboard() {
   function handleGmailConnect() {
     // return_to must be an origin registered in the backend's ALLOWED_ORIGINS env var.
     // Add any new deployment URLs there before enabling Gmail connect on that host.
-    const returnTo = window.location.origin + window.location.pathname;
+    const returnTo =
+      window.location.origin +
+      window.location.pathname +
+      window.location.search +
+      window.location.hash;
     // Full browser navigation required — OAuth flow must follow redirects, not fetch.
     window.location.href = `/api/agent/gmail/connect?return_to=${encodeURIComponent(returnTo)}`;
   }


### PR DESCRIPTION
## Summary
- Add a **Tools** tab to the right panel (alongside existing Context tab), giving visibility into which tools are active/inactive
- New `GET /tools/info` backend endpoint returns all tools with `active` boolean status
- New `ToolsDashboard` component lists all tools with colour-coded badges and a Gmail integration card (connect / disconnect / refresh)
- Gmail OAuth flow: "Connect Gmail" navigates to `/api/agent/gmail/connect`; after callback, `?gmail=connected` param is stripped and status is re-fetched without a full page reload
- Fix pre-existing type annotation: `get_tool_info` return type corrected from `List[Dict[str, str]]` to `List[Dict[str, Any]]`

## Linked Issue
Closes #211

## Validation
- [ ] `python -m unittest discover -s tests -p "test_*.py" -v`
- [ ] `python tests/run_repo_checks.py`
- Frontend lint: `npm run lint` — no errors (one pre-existing warning in WorkspaceApp.jsx unrelated to this PR)
- `cubic review --base main` — **No issues found**
- No LLM/tool-calling behavior changed; no evals required

## Workflow Checklist
- [x] Branch created via managed worktree slot (not `main`)
- [x] Rebased against latest `origin/main` before push/PR
- [x] Commits are granular and focused
- [x] CI checks pass
- [x] Merge method will be **Squash and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tools tab in the right panel to view tool status and manage the Gmail integration. Introduces `GET /tools/info` with active flags and hardens Gmail OAuth and tool registry; closes #211.

- **New Features**
  - Tools tab alongside Context with a `ToolsDashboard` that lists all tools with active/inactive badges from `GET /tools/info` (A–Z).
  - `GET /tools/info` returns `ToolInfoWithStatus` (extends `ToolInfo`) and uses `offload_blocking_call` to avoid blocking.
  - Gmail card: connect via `/api/agent/gmail/connect?return_to=...`, disconnect via `DELETE /gmail/connection`, refresh; strips `?gmail=connected` on callback without a reload and refreshes tool badges after disconnect.

- **Bug Fixes**
  - Gmail OAuth: removed `include_granted_scopes`; `return_to` built with the URL constructor and only forwards the `?conversation` param so chat context survives the round‑trip without leaking other query params.
  - Tool registry: `get_tool_info` return type updated to `List[Dict[str, Any]]`; snapshot tool items after `get_available_tools()` so newly activated tools are included and to avoid concurrent modification during capability refresh.
  - ToolsDashboard: show fetch errors; clear stale state (reset `toolsError` on retry, clear `gmailStatus` on error); reset `toolsLoading` on each refetch; refresh tools after disconnect and guarantee the Gmail loading spinner resets even if the tools refresh fails; defensive optional chaining on Gmail button title.

<sup>Written for commit b3943f171641fcc90ad4fa9ab6dc469222893648. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

